### PR TITLE
Fix zip signing

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -109,7 +109,8 @@
     <!-- zip and sign it --> 
     <zip destfile="${build.dir}/unsigned.zip" basedir="${work.dir}"></zip>
     <echo message="Signing gapps"/>
-      <java dir="${build.dir}" fork="true" failonerror="true" maxmemory="128m" jar="${sign.jar}">
+      <java dir="${build.dir}" fork="true" failonerror="true" maxmemory="1536m" jar="${sign.jar}">
+      <arg value="-w"/>
       <arg value="${sign.pem}"/>
       <arg value="${sign.pk8}"/>
       <arg value="${build.dir}/unsigned.zip"/>
@@ -161,7 +162,8 @@
     <!-- zip and sign it -->
     <zip destfile="${build.dir}/unsigned.zip" basedir="${work.dir}"></zip>
     <echo message="Signing gapps"/>
-    <java dir="${build.dir}" fork="true" failonerror="true" maxmemory="128m" jar="${sign.jar}">
+    <java dir="${build.dir}" fork="true" failonerror="true" maxmemory="1536m" jar="${sign.jar}">
+      <arg value="-w"/>
       <arg value="${sign.pem}"/>
       <arg value="${sign.pk8}"/>
       <arg value="${build.dir}/unsigned.zip"/>
@@ -199,7 +201,8 @@
     <!-- zip and sign it -->
     <zip destfile="${build.dir}/unsigned.zip" basedir="${work.dir}"></zip>
     <echo message="Signing gapps"/>
-    <java dir="${build.dir}" fork="true" failonerror="true" maxmemory="128m" jar="${sign.jar}">
+    <java dir="${build.dir}" fork="true" failonerror="true" maxmemory="1536m" jar="${sign.jar}">
+      <arg value="-w"/>
       <arg value="${sign.pem}"/>
       <arg value="${sign.pk8}"/>
       <arg value="${build.dir}/unsigned.zip"/>


### PR DESCRIPTION
- Added "-w" argument( about "-w" argument: " I figure out what the -w setting is, it is Sign Whole file and it is necesary to sign the final zip file. Reading the source code of SignApk I can see the output stream is done in memory in a bytearray buffer when -w setting is used, when this bytearray is filled with zip with all signed internal files a final procedure take this memory data and sign the whole thing to finally write this in outputfile, so thats the problem." source: http://www.openhandhelds.net/forum2/index.php?/topic/66-fix-signapk-memory-useage-problem-and-fix/#entry388
- Changed java maxmemory to 1536 MB in order for signapk to work properly
