### PR TITLE
Fix file.list

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -96,7 +96,7 @@
     </copy>
 
     <!-- generate backup script --> 
-    <fileset id="item.file" dir="${work.dir}/system" includes="**/*.*" />
+    <fileset id="item.file" dir="${work.dir}/system" includes="**/*" />
     <pathconvert refid="item.file" property="file.list.zero" pathsep="&#10;" dirsep="/">
         <map from="${work.dir}/system/" to=''/>
     </pathconvert>
@@ -163,7 +163,7 @@
     </copy>
 
     <!-- generate backup script --> 
-    <fileset id="item.file" dir="${work.dir}/system" includes="**/*.*" />
+    <fileset id="item.file" dir="${work.dir}/system" includes="**/*" />
     <pathconvert refid="item.file" property="file.list.mini" pathsep="&#10;" dirsep="/">
         <map from="${work.dir}/system/" to=''/>
     </pathconvert>
@@ -211,7 +211,7 @@
     </copy>
 
     <!-- generate backup script --> 
-    <fileset id="item.file" dir="${work.dir}/system" includes="**/*.*" />
+    <fileset id="item.file" dir="${work.dir}/system" includes="**/*" />
     <pathconvert refid="item.file" property="file.list.normal" pathsep="&#10;" dirsep="/">
         <map from="${work.dir}/system/" to=''/>
     </pathconvert>
@@ -249,7 +249,7 @@
     </copy>
 
     <!-- generate backup script --> 
-    <fileset id="item.file" dir="${work.dir}/system" includes="**/*.*" />
+    <fileset id="item.file" dir="${work.dir}/system" includes="**/*" />
     <pathconvert refid="item.file" property="file.list.full" pathsep="&#10;" dirsep="/">
         <map from="${work.dir}/system/" to=''/>
     </pathconvert>
@@ -269,7 +269,7 @@
   <!-- generate clean up list                                                     -->
   <!--=======================================================================-->
   <target name="generateCleanUpList">
-    <fileset id="cleanup.file" dir="${structure.dir}/system" includes="**/*.*" />
+    <fileset id="cleanup.file" dir="${structure.dir}/system" includes="**/*" />
 	<pathconvert refid="cleanup.file" property="cleanup.list" pathsep="&quot;,&#10;&quot;" dirsep="/">
 		<map from="${structure.dir}/system/" to="/system/"/>
     </pathconvert>


### PR DESCRIPTION
Old: `includes="**/*.*"` ->this one includes only files with extension, but the Google Keyboard lib contains some files without extension and they were excluded
New: `includes="**/*"`
