### PR TITLE
remove obsolete lib files from 80-gapps.sh

### DIFF
--- a/extras/80-gapps.sh
+++ b/extras/80-gapps.sh
@@ -15,8 +15,6 @@ framework/com.google.android.camera2.jar
 lib/libgcam.so
 lib/libgcam_swig_jni.so
 lib/libjni_eglfence.so
-lib/libjni_filtershow_filters.so
-lib/libjni_mosaic.so
 lib/liblightcycle.so
 lib/libnativehelper_compat.so
 vendor/pittpatt/models/detection/multi_pose_face_landmark_detectors.8/landmark_group_meta_data.bin


### PR DESCRIPTION
Removed the flowing files from 80-gapps.sh since they are no longer included in the packages.

lib/libjni_filtershow_filters.so
lib/libjni_mosaic.so
