### PR TITLE
remove extra lines

### DIFF
--- a/extras/80-gapps.sh
+++ b/extras/80-gapps.sh
@@ -6,27 +6,6 @@
 
 list_files() {
 cat <<EOF
-addon.d/80-gapps.sh
-addon.d/71-gapps-faceunlock.sh
-app/FaceLock/FaceLock.apk
-app/FaceLock/lib/arm/libfacelock_jni.so
-etc/permissions/com.google.android.camera2.xml
-framework/com.google.android.camera2.jar
-lib/libgcam.so
-lib/libgcam_swig_jni.so
-lib/libjni_eglfence.so
-lib/liblightcycle.so
-lib/libnativehelper_compat.so
-vendor/pittpatt/models/detection/multi_pose_face_landmark_detectors.8/landmark_group_meta_data.bin
-vendor/pittpatt/models/detection/multi_pose_face_landmark_detectors.8/left_eye-y0-yi45-p0-pi45-r0-ri20.lg_32-tree7-wmd.bin
-vendor/pittpatt/models/detection/multi_pose_face_landmark_detectors.8/nose_base-y0-yi45-p0-pi45-r0-ri20.lg_32-tree7-wmd.bin
-vendor/pittpatt/models/detection/multi_pose_face_landmark_detectors.8/right_eye-y0-yi45-p0-pi45-r0-ri20.lg_32-3-tree7-wmd.bin
-vendor/pittpatt/models/detection/yaw_roll_face_detectors.7.1/head-y0-yi45-p0-pi45-r0-ri30.4a-v24-tree7-2-wmd.bin
-vendor/pittpatt/models/detection/yaw_roll_face_detectors.7.1/head-y0-yi45-p0-pi45-rn30-ri30.5-v24-tree7-2-wmd.bin
-vendor/pittpatt/models/detection/yaw_roll_face_detectors.7.1/head-y0-yi45-p0-pi45-rp30-ri30.5-v24-tree7-2-wmd.bin
-vendor/pittpatt/models/detection/yaw_roll_face_detectors.7.1/pose-r.8.1.bin
-vendor/pittpatt/models/detection/yaw_roll_face_detectors.7.1/pose-y-r.8.1.bin
-vendor/pittpatt/models/recognition/face.face.y0-y0-71-N-tree_7-wmd.bin
 @file.list@
 EOF
 }


### PR DESCRIPTION
from firmware slim(backup script: /system/bin/backuptool.sh)

-addon.d/80-gapps.sh
-addon.d/71-gapps-faceunlock.sh

including them, we will duplicate the following functions

<blockquote><pre>
# Preserve /system/addon.d in /tmp/addon.d
preserve_addon_d() {
  mkdir -p /tmp/addon.d/
  cp -a /system/addon.d/* /tmp/addon.d/  #!!!
  chmod 755 /tmp/addon.d/*.sh
}

restore_addon_d() {
  cp -a /tmp/addon.d/* /system/addon.d/
  rm -rf /tmp/addon.d/
}

# scans all files from addon.d
run_stage() { 
for script in $(find /tmp/addon.d/ -name '*.sh' |sort -n); do
  $script $1
done
}<pre>
</blockquote>


already exists in

/structure/optional/face/addon.d/71-gapps-faceunlock.sh

-app/FaceLock/FaceLock.apk
-app/FaceLock/lib/arm/libfacelock_jni.so
-etc/permissions/com.google.android.camera2.xml
-framework/com.google.android.camera2.jar
-lib/libgcam.so
-lib/libgcam_swig_jni.so
-lib/libjni_eglfence.so
-lib/liblightcycle.so
-lib/libnativehelper_compat.so
-vendor/pittpatt/models/detection/multi_pose_face_landmark_detectors.8/landmark_group_meta_data.bin
-vendor/pittpatt/models/detection/multi_pose_face_landmark_detectors.8/left_eye-y0-yi45-p0-pi45-r0-ri20.lg_32-tree7-wmd.bin
-vendor/pittpatt/models/detection/multi_pose_face_landmark_detectors.8/nose_base-y0-yi45-p0-pi45-r0-ri20.lg_32-tree7-wmd.bin
-vendor/pittpatt/models/detection/multi_pose_face_landmark_detectors.8/right_eye-y0-yi45-p0-pi45-r0-ri20.lg_32-3-tree7-wmd.bin
-vendor/pittpatt/models/detection/yaw_roll_face_detectors.7.1/head-y0-yi45-p0-pi45-r0-ri30.4a-v24-tree7-2-wmd.bin
-vendor/pittpatt/models/detection/yaw_roll_face_detectors.7.1/head-y0-yi45-p0-pi45-rn30-ri30.5-v24-tree7-2-wmd.bin
-vendor/pittpatt/models/detection/yaw_roll_face_detectors.7.1/head-y0-yi45-p0-pi45-rp30-ri30.5-v24-tree7-2-wmd.bin
-vendor/pittpatt/models/detection/yaw_roll_face_detectors.7.1/pose-r.8.1.bin
-vendor/pittpatt/models/detection/yaw_roll_face_detectors.7.1/pose-y-r.8.1.bin
-vendor/pittpatt/models/recognition/face.face.y0-y0-71-N-tree_7-wmd.bin
